### PR TITLE
infernal multithreading

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -869,7 +869,7 @@ process runInfernal {
     TRSIZE=\$(perl -E "say \${SIZE} * 2 / 1e6")
 
     cmscan \
-      --cpu 1 \
+      ---cpu "${task.cpus}" \
       -Z "\${TRSIZE}" \
       --cut_ga \
       --rfam \


### PR DESCRIPTION
fixed hardcoded CPU=1 to take advantage of multiple CPUs

[issue #25](https://github.com/KristinaGagalova/pante2-legacy/issues/25)